### PR TITLE
Add-invariant-for-missing-data-logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,6 @@ node_modules
 # testing
 coverage
 
-# production
-lib
-
 # misc
 .DS_Store
 .env

--- a/lib/EmptyRadar.js
+++ b/lib/EmptyRadar.js
@@ -1,0 +1,103 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+exports.default = EmptyRadar;
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _RadarAxis = require('./RadarAxis');
+
+var _RadarAxis2 = _interopRequireDefault(_RadarAxis);
+
+var _RadarRings = require('./RadarRings');
+
+var _RadarRings2 = _interopRequireDefault(_RadarRings);
+
+var _utils = require('./utils');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var defaultRadarStyle = {
+  numRings: 4,
+  axisColor: '#cdcdcd',
+  ringColor: '#cdcdcd'
+};
+
+function EmptyRadar(props) {
+  var width = props.width,
+      height = props.height,
+      padding = props.padding,
+      variables = props.variables,
+      domainMax = props.domainMax,
+      style = props.style;
+
+  var _defaultRadarStyle$st = _extends({}, defaultRadarStyle, style),
+      axisColor = _defaultRadarStyle$st.axisColor,
+      ringColor = _defaultRadarStyle$st.ringColor,
+      numRings = _defaultRadarStyle$st.numRings;
+
+  var innerHeight = height - padding * 2;
+  var innerWidth = width - padding * 2;
+
+  var radius = Math.min(innerWidth / 2, innerHeight / 2);
+  var diameter = radius * 2;
+
+  var scales = (0, _utils.radiusScales)(variables, domainMax, radius);
+
+  var angleSliceRadians = Math.PI * 2 / variables.length;
+  var offsetAngles = {};
+  (0, _utils.forEachArray)(variables, function (_ref, i) {
+    var key = _ref.key;
+
+    offsetAngles[key] = angleSliceRadians * i;
+  });
+
+  var backgroundScale = scales[variables[0].key];
+  var ticks = backgroundScale.ticks(numRings).slice(1);
+  var tickFormat = backgroundScale.tickFormat(numRings);
+
+  return _react2.default.createElement(
+    'svg',
+    { width: width, height: height },
+    _react2.default.createElement(
+      'g',
+      { transform: 'translate(' + padding + ', ' + padding + ')' },
+      _react2.default.createElement('rect', {
+        width: diameter,
+        height: diameter,
+        fill: 'transparent',
+        transform: 'translate(' + (innerWidth - diameter) / 2 + ', ' + (innerHeight - diameter) / 2 + ')'
+      }),
+      _react2.default.createElement(
+        'g',
+        { transform: 'translate(' + innerWidth / 2 + ', ' + innerHeight / 2 + ')' },
+        _react2.default.createElement(_RadarRings2.default, {
+          ticks: ticks,
+          scale: backgroundScale,
+          color: ringColor,
+          format: tickFormat
+        }),
+        variables.map(function (_ref2) {
+          var key = _ref2.key,
+              label = _ref2.label;
+
+          return _react2.default.createElement(_RadarAxis2.default, {
+            key: key,
+            scale: scales[key],
+            offsetAngle: offsetAngles[key],
+            label: label,
+            domainMax: domainMax,
+            color: axisColor
+          });
+        })
+      )
+    )
+  );
+}

--- a/lib/EmptyRadar.js.flow
+++ b/lib/EmptyRadar.js.flow
@@ -1,0 +1,80 @@
+// @flow
+import React from 'react';
+import RadarAxis from './RadarAxis';
+import RadarRings from './RadarRings';
+import type {RadarVariable} from './types';
+import {radiusScales, forEachArray} from './utils';
+
+type Props = {
+  width: number,
+  height: number,
+  padding: number,
+  variables: Array<RadarVariable>,
+  domainMax: number,
+  style?: {},
+};
+
+const defaultRadarStyle = {
+  numRings: 4,
+  axisColor: '#cdcdcd',
+  ringColor: '#cdcdcd',
+};
+
+export default function EmptyRadar(props: Props) {
+  const {width, height, padding, variables, domainMax, style} = props;
+  const {axisColor, ringColor, numRings} = {...defaultRadarStyle, ...style};
+  const innerHeight = height - padding * 2;
+  const innerWidth = width - padding * 2;
+
+  const radius = Math.min(innerWidth / 2, innerHeight / 2);
+  const diameter = radius * 2;
+
+  const scales = radiusScales(variables, domainMax, radius);
+
+  const angleSliceRadians = Math.PI * 2 / variables.length;
+  const offsetAngles = {};
+  forEachArray(variables, ({key}, i) => {
+    offsetAngles[key] = angleSliceRadians * i;
+  });
+
+  const backgroundScale = scales[variables[0].key];
+  const ticks = backgroundScale.ticks(numRings).slice(1);
+  const tickFormat = backgroundScale.tickFormat(numRings);
+
+  return (
+    <svg width={width} height={height}>
+      <g transform={`translate(${padding}, ${padding})`}>
+        <rect
+          width={diameter}
+          height={diameter}
+          fill={'transparent'}
+          transform={
+            `translate(${(innerWidth - diameter) / 2}, ${(innerHeight -
+              diameter) /
+              2})`
+          }
+        />
+        <g transform={`translate(${innerWidth / 2}, ${innerHeight / 2})`}>
+          <RadarRings
+            ticks={ticks}
+            scale={backgroundScale}
+            color={ringColor}
+            format={tickFormat}
+          />
+          {variables.map(({key, label}) => {
+            return (
+              <RadarAxis
+                key={key}
+                scale={scales[key]}
+                offsetAngle={offsetAngles[key]}
+                label={label}
+                domainMax={domainMax}
+                color={axisColor}
+              />
+            );
+          })}
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/lib/Radar.js
+++ b/lib/Radar.js
@@ -1,0 +1,122 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
+exports.default = Radar;
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _d3Scale = require('d3-scale');
+
+var _d3Voronoi = require('d3-voronoi');
+
+var _lodash = require('lodash');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+var _utils = require('./utils');
+
+var _RadarWrapper = require('./RadarWrapper');
+
+var _RadarWrapper2 = _interopRequireDefault(_RadarWrapper);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function convertData(props) {
+  var data = props.data,
+      width = props.width,
+      height = props.height,
+      padding = props.padding,
+      domainMax = props.domainMax;
+
+  var innerHeight = height - padding * 2;
+  var innerWidth = width - padding * 2;
+
+  var radius = Math.min(innerWidth / 2, innerHeight / 2);
+  var scales = (0, _utils.radiusScales)(data.variables, domainMax, radius);
+
+  var angleSliceRadians = Math.PI * 2 / data.variables.length;
+  var offsetAngles = {};
+  (0, _utils.forEachArray)(data.variables, function (_ref, i) {
+    var key = _ref.key;
+
+    offsetAngles[key] = angleSliceRadians * i;
+  });
+
+  var allPoints = (0, _utils.radarPoints)(data, scales, offsetAngles);
+  var flatPointList = (0, _utils.flatMapDeepArray)(allPoints, function (_ref2) {
+    var points = _ref2.points;
+
+    return points;
+  });
+
+  var voronoiDiagram = (0, _d3Voronoi.voronoi)().x(function (d) {
+    return d.x + radius;
+  }).y(function (d) {
+    return d.y + radius;
+  }).size([radius * 2, radius * 2])(flatPointList);
+
+  return { allPoints: allPoints, scales: scales, offsetAngles: offsetAngles, voronoiDiagram: voronoiDiagram, radius: radius };
+}
+
+function Radar(props) {
+  var data = props.data,
+      width = props.width,
+      height = props.height,
+      padding = props.padding,
+      domainMax = props.domainMax,
+      style = props.style,
+      onHover = props.onHover,
+      highlighted = props.highlighted;
+
+  var _convertData = convertData(props),
+      allPoints = _convertData.allPoints,
+      scales = _convertData.scales,
+      offsetAngles = _convertData.offsetAngles,
+      radius = _convertData.radius,
+      voronoiDiagram = _convertData.voronoiDiagram;
+
+  var highlightedSetKey = highlighted ? highlighted.setKey : null;
+
+  var backgroundScale = scales[data.variables[0].key];
+
+  var colors = {};
+  (0, _utils.forEachArray)(allPoints, function (_ref3, idx) {
+    var setKey = _ref3.setKey;
+
+    colors[setKey] = _d3Scale.schemeCategory10[idx];
+  });
+
+  var _$partition = _lodash2.default.partition(allPoints, function (_ref4) {
+    var setKey = _ref4.setKey;
+    return setKey === highlightedSetKey;
+  }),
+      _$partition2 = _slicedToArray(_$partition, 2),
+      highlightedPoints = _$partition2[0],
+      regularPoints = _$partition2[1];
+
+  return _react2.default.createElement(_RadarWrapper2.default, {
+    variables: data.variables,
+    width: width,
+    height: height,
+    padding: padding,
+    domainMax: domainMax,
+    style: style,
+    onHover: onHover,
+    highlighted: highlighted,
+    scales: scales,
+    backgroundScale: backgroundScale,
+    offsetAngles: offsetAngles,
+    voronoiDiagram: voronoiDiagram,
+    radius: radius,
+    highlightedPoint: highlightedPoints.length > 0 ? highlightedPoints[0] : null,
+    regularPoints: regularPoints,
+    colors: colors
+  });
+}

--- a/lib/Radar.js.flow
+++ b/lib/Radar.js.flow
@@ -1,0 +1,104 @@
+// @flow
+import React from 'react';
+import {schemeCategory10} from 'd3-scale';
+import {voronoi} from 'd3-voronoi';
+import _ from 'lodash';
+import {
+  flatMapDeepArray,
+  forEachArray,
+  radarPoints,
+  radiusScales,
+} from './utils';
+import type {RadarPoint, RadarData} from './types';
+import RadarWrapper from './RadarWrapper';
+
+type Props = {
+  data: RadarData,
+  width: number,
+  height: number,
+  padding: number,
+  domainMax: number,
+  style?: {},
+  onHover?: (point: RadarPoint | null) => void,
+  highlighted: ?RadarPoint,
+};
+
+function convertData(props) {
+  const {data, width, height, padding, domainMax} = props;
+  const innerHeight = height - padding * 2;
+  const innerWidth = width - padding * 2;
+
+  const radius = Math.min(innerWidth / 2, innerHeight / 2);
+  const scales = radiusScales(data.variables, domainMax, radius);
+
+  const angleSliceRadians = Math.PI * 2 / data.variables.length;
+  const offsetAngles = {};
+  forEachArray(data.variables, ({key}, i) => {
+    offsetAngles[key] = angleSliceRadians * i;
+  });
+
+  const allPoints = radarPoints(data, scales, offsetAngles);
+  const flatPointList = flatMapDeepArray(allPoints, ({points}) => {
+    return points;
+  });
+
+  const voronoiDiagram = voronoi()
+    .x((d: RadarPoint) => d.x + radius)
+    .y((d: RadarPoint) => d.y + radius)
+    .size([radius * 2, radius * 2])(flatPointList);
+
+  return {allPoints, scales, offsetAngles, voronoiDiagram, radius};
+}
+
+export default function Radar(props: Props) {
+  const {
+    data,
+    width,
+    height,
+    padding,
+    domainMax,
+    style,
+    onHover,
+    highlighted,
+  } = props;
+  const {allPoints, scales, offsetAngles, radius, voronoiDiagram} = convertData(
+    props,
+  );
+
+  const highlightedSetKey = highlighted ? highlighted.setKey : null;
+
+  const backgroundScale = scales[data.variables[0].key];
+
+  const colors = {};
+  forEachArray(allPoints, ({setKey}, idx) => {
+    colors[setKey] = schemeCategory10[idx];
+  });
+
+  const [highlightedPoints, regularPoints] = _.partition(
+    allPoints,
+    ({setKey}) => setKey === highlightedSetKey,
+  );
+
+  return (
+    <RadarWrapper
+      variables={data.variables}
+      width={width}
+      height={height}
+      padding={padding}
+      domainMax={domainMax}
+      style={style}
+      onHover={onHover}
+      highlighted={highlighted}
+      scales={scales}
+      backgroundScale={backgroundScale}
+      offsetAngles={offsetAngles}
+      voronoiDiagram={voronoiDiagram}
+      radius={radius}
+      highlightedPoint={
+        highlightedPoints.length > 0 ? highlightedPoints[0] : null
+      }
+      regularPoints={regularPoints}
+      colors={colors}
+    />
+  );
+}

--- a/lib/RadarAxis.js
+++ b/lib/RadarAxis.js
@@ -1,0 +1,74 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+exports.default = RadarAxis;
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var defaultRadarAxisStyle = {
+  axisOverreach: 1.1,
+  labelOverreach: 1.42,
+  fontSize: 10,
+  fontFamily: 'sans-serif',
+  textFill: 'black',
+  axisWidth: 2
+};
+
+function RadarAxis(props) {
+  var scale = props.scale,
+      offsetAngle = props.offsetAngle,
+      domainMax = props.domainMax,
+      label = props.label,
+      color = props.color,
+      style = props.style;
+
+  var _defaultRadarAxisStyl = _extends({}, defaultRadarAxisStyle, { style: style }),
+      axisOverreach = _defaultRadarAxisStyl.axisOverreach,
+      labelOverreach = _defaultRadarAxisStyl.labelOverreach,
+      fontSize = _defaultRadarAxisStyl.fontSize,
+      fontFamily = _defaultRadarAxisStyl.fontFamily,
+      textFill = _defaultRadarAxisStyl.textFill,
+      axisWidth = _defaultRadarAxisStyl.axisWidth;
+
+  var xFactor = Math.cos(offsetAngle - Math.PI / 2);
+  var yFactor = Math.sin(offsetAngle - Math.PI / 2);
+  return _react2.default.createElement(
+    'g',
+    null,
+    _react2.default.createElement('line', {
+      x1: 0,
+      y1: 0,
+      x2: scale(domainMax * axisOverreach) * xFactor,
+      y2: scale(domainMax * axisOverreach) * yFactor,
+      stroke: color,
+      strokeWidth: axisWidth
+    }),
+    _react2.default.createElement(
+      'foreignObject',
+      {
+        x: scale(domainMax * labelOverreach * xFactor - 26),
+        y: scale(domainMax * labelOverreach * (yFactor * 0.87) - 7),
+        dy: '0.35em',
+        dx: '0.35em'
+      },
+      _react2.default.createElement(
+        'div',
+        null,
+        _react2.default.createElement(
+          'p',
+          null,
+          label
+        )
+      )
+    )
+  );
+}

--- a/lib/RadarAxis.js.flow
+++ b/lib/RadarAxis.js.flow
@@ -1,0 +1,57 @@
+// @flow
+import React from 'react';
+import type {TickScale} from './types';
+
+type RadarAxisProps = {
+  scale: TickScale,
+  offsetAngle: number,
+  domainMax: number,
+  label: string,
+  color: string,
+  style?: {},
+};
+
+const defaultRadarAxisStyle = {
+  axisOverreach: 1.1,
+  labelOverreach: 1.42,
+  fontSize: 10,
+  fontFamily: 'sans-serif',
+  textFill: 'black',
+  axisWidth: 2,
+};
+
+export default function RadarAxis(props: RadarAxisProps) {
+  const {scale, offsetAngle, domainMax, label, color, style} = props;
+  const {
+    axisOverreach,
+    labelOverreach,
+    fontSize,
+    fontFamily,
+    textFill,
+    axisWidth,
+  } = {...defaultRadarAxisStyle, style};
+  const xFactor = Math.cos(offsetAngle - Math.PI / 2);
+  const yFactor = Math.sin(offsetAngle - Math.PI / 2);
+  return (
+    <g>
+      <line
+        x1={0}
+        y1={0}
+        x2={scale(domainMax * axisOverreach) * xFactor}
+        y2={scale(domainMax * axisOverreach) * yFactor}
+        stroke={color}
+        strokeWidth={axisWidth}
+      />
+      <foreignObject
+        x={scale(((domainMax * labelOverreach) * xFactor) - 26)}
+        y={scale(((domainMax * labelOverreach) * (yFactor * 0.87)) - 7)}
+        dy={'0.35em'}
+        dx={'0.35em'}
+      >
+        <div>
+          <p>{label}</p>
+        </div>
+      </foreignObject>
+    </g>
+  );
+}

--- a/lib/RadarCircle.js
+++ b/lib/RadarCircle.js
@@ -1,0 +1,82 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+exports.default = RadarCircle;
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _lodash = require('lodash');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+var _d3Shape = require('d3-shape');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var defaultCircleStyle = {
+  selectedFillOpacity: 0.5,
+  inactiveFillOpacity: 0.2,
+  selectedStrokeOpacity: 1.0,
+  inactiveStrokeOpacity: 0.7,
+  pointRadius: 3,
+  selectedPointFill: 'white',
+  selectedPointOpacity: 1.0,
+  inactivePointOpacity: 0.7
+};
+
+function RadarCircle(props) {
+  var points = props.points,
+      scales = props.scales,
+      offsetAngles = props.offsetAngles,
+      isSelected = props.isSelected,
+      color = props.color,
+      selectedVariableKey = props.selectedVariableKey,
+      style = props.style;
+
+  var _defaultCircleStyle$s = _extends({}, defaultCircleStyle, style),
+      selectedFillOpacity = _defaultCircleStyle$s.selectedFillOpacity,
+      inactiveFillOpacity = _defaultCircleStyle$s.inactiveFillOpacity,
+      selectedStrokeOpacity = _defaultCircleStyle$s.selectedStrokeOpacity,
+      inactiveStrokeOpacity = _defaultCircleStyle$s.inactiveStrokeOpacity,
+      pointRadius = _defaultCircleStyle$s.pointRadius,
+      selectedPointFill = _defaultCircleStyle$s.selectedPointFill,
+      selectedPointOpacity = _defaultCircleStyle$s.selectedPointOpacity,
+      inactivePointOpacity = _defaultCircleStyle$s.inactivePointOpacity;
+
+  var lineFunction = (0, _d3Shape.radialLine)().radius(function (point) {
+    return scales[point.variableKey](point.value);
+  }).angle(function (point) {
+    return _lodash2.default.round(offsetAngles[point.variableKey], 6);
+  }).curve(_d3Shape.curveCardinalClosed);
+
+  var pathData = lineFunction(points);
+  return _react2.default.createElement(
+    'g',
+    null,
+    _react2.default.createElement('path', {
+      d: pathData,
+      fill: color,
+      fillOpacity: isSelected ? selectedFillOpacity : inactiveFillOpacity,
+      stroke: color,
+      strokeOpacity: isSelected ? selectedStrokeOpacity : inactiveStrokeOpacity
+    }),
+    points.map(function (point) {
+      return _react2.default.createElement('circle', {
+        key: point.key,
+        r: pointRadius,
+        fill: point.variableKey === selectedVariableKey ? selectedPointFill : color,
+        stroke: color,
+        cx: point.x,
+        cy: point.y,
+        opacity: isSelected ? selectedPointOpacity : inactivePointOpacity
+      });
+    })
+  );
+}

--- a/lib/RadarCircle.js.flow
+++ b/lib/RadarCircle.js.flow
@@ -1,0 +1,85 @@
+// @flow
+import React from 'react';
+import _ from 'lodash';
+import {radialLine, curveCardinalClosed} from 'd3-shape';
+import type {TickScale, RadarPoint} from './types';
+
+type RadarCircleProps = {
+  points: Array<RadarPoint>,
+  scales: {[variableKey: string]: TickScale},
+  offsetAngles: {[variableKey: string]: number},
+  isSelected: boolean,
+  selectedVariableKey: ?string,
+  color: string,
+  style?: {},
+};
+
+const defaultCircleStyle = {
+  selectedFillOpacity: 0.5,
+  inactiveFillOpacity: 0.2,
+  selectedStrokeOpacity: 1.0,
+  inactiveStrokeOpacity: 0.7,
+  pointRadius: 3,
+  selectedPointFill: 'white',
+  selectedPointOpacity: 1.0,
+  inactivePointOpacity: 0.7,
+};
+
+export default function RadarCircle(props: RadarCircleProps) {
+  const {
+    points,
+    scales,
+    offsetAngles,
+    isSelected,
+    color,
+    selectedVariableKey,
+    style,
+  } = props;
+  const {
+    selectedFillOpacity,
+    inactiveFillOpacity,
+    selectedStrokeOpacity,
+    inactiveStrokeOpacity,
+    pointRadius,
+    selectedPointFill,
+    selectedPointOpacity,
+    inactivePointOpacity,
+  } = {...defaultCircleStyle, ...style};
+
+  const lineFunction = radialLine()
+    .radius((point: RadarPoint) => scales[point.variableKey](point.value))
+    .angle((point: RadarPoint) => _.round(offsetAngles[point.variableKey], 6))
+    .curve(curveCardinalClosed);
+
+  const pathData = lineFunction(points);
+  return (
+    <g>
+      <path
+        d={pathData}
+        fill={color}
+        fillOpacity={isSelected ? selectedFillOpacity : inactiveFillOpacity}
+        stroke={color}
+        strokeOpacity={
+          isSelected ? selectedStrokeOpacity : inactiveStrokeOpacity
+        }
+      />
+      {points.map(point => {
+        return (
+          <circle
+            key={point.key}
+            r={pointRadius}
+            fill={
+              point.variableKey === selectedVariableKey
+                ? selectedPointFill
+                : color
+            }
+            stroke={color}
+            cx={point.x}
+            cy={point.y}
+            opacity={isSelected ? selectedPointOpacity : inactivePointOpacity}
+          />
+        );
+      })}
+    </g>
+  );
+}

--- a/lib/RadarRings.js
+++ b/lib/RadarRings.js
@@ -1,0 +1,72 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+exports.default = RadarRings;
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _lodash = require('lodash');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var defaultRadarRingsStyle = {
+  fontFamily: 'sans-serif',
+  fontSize: 10,
+  ringOpacity: 0.1,
+  textFill: 'black'
+};
+
+function RadarRings(props) {
+  var ticks = props.ticks,
+      scale = props.scale,
+      color = props.color,
+      format = props.format,
+      style = props.style;
+
+  var _defaultRadarRingsSty = _extends({}, defaultRadarRingsStyle, style),
+      fontFamily = _defaultRadarRingsSty.fontFamily,
+      fontSize = _defaultRadarRingsSty.fontSize,
+      ringOpacity = _defaultRadarRingsSty.ringOpacity,
+      textFill = _defaultRadarRingsSty.textFill;
+
+  var outerFirst = _lodash2.default.reverse(ticks);
+  return _react2.default.createElement(
+    'g',
+    null,
+    outerFirst.map(function (tickValue) {
+      return _react2.default.createElement('circle', {
+        key: '' + tickValue,
+        fillOpacity: ringOpacity,
+        fill: color,
+        stroke: color,
+        r: scale(tickValue)
+      });
+    }),
+    outerFirst.map(function (tickValue) {
+      return _react2.default.createElement(
+        'text',
+        {
+          key: tickValue + '-tick',
+          x: 0,
+          y: -scale(tickValue),
+          dx: '0.4em',
+          dy: '0.4em',
+          fontFamily: fontFamily,
+          fontSize: fontSize,
+          textAnchor: 'left',
+          fill: textFill
+        },
+        format(tickValue)
+      );
+    })
+  );
+}

--- a/lib/RadarRings.js.flow
+++ b/lib/RadarRings.js.flow
@@ -1,0 +1,60 @@
+// @flow
+import React from 'react';
+import _ from 'lodash';
+import type {TickScale} from './types';
+
+type RadarRingsProps = {
+  ticks: Array<number>,
+  scale: TickScale,
+  color: string,
+  format(number): string,
+  style?: {},
+};
+
+const defaultRadarRingsStyle = {
+  fontFamily: 'sans-serif',
+  fontSize: 10,
+  ringOpacity: 0.1,
+  textFill: 'black',
+};
+
+export default function RadarRings(props: RadarRingsProps) {
+  const {ticks, scale, color, format, style} = props;
+  const {fontFamily, fontSize, ringOpacity, textFill} = {
+    ...defaultRadarRingsStyle,
+    ...style,
+  };
+  const outerFirst = _.reverse(ticks);
+  return (
+    <g>
+      {outerFirst.map(tickValue => {
+        return (
+          <circle
+            key={`${tickValue}`}
+            fillOpacity={ringOpacity}
+            fill={color}
+            stroke={color}
+            r={scale(tickValue)}
+          />
+        );
+      })}
+      {outerFirst.map(tickValue => {
+        return (
+          <text
+            key={`${tickValue}-tick`}
+            x={0}
+            y={-scale(tickValue)}
+            dx={'0.4em'}
+            dy={'0.4em'}
+            fontFamily={fontFamily}
+            fontSize={fontSize}
+            textAnchor={'left'}
+            fill={textFill}
+          >
+            {format(tickValue)}
+          </text>
+        );
+      })}
+    </g>
+  );
+}

--- a/lib/RadarWrapper.js
+++ b/lib/RadarWrapper.js
@@ -1,0 +1,209 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _RadarAxis = require('./RadarAxis');
+
+var _RadarAxis2 = _interopRequireDefault(_RadarAxis);
+
+var _RadarCircle = require('./RadarCircle');
+
+var _RadarCircle2 = _interopRequireDefault(_RadarCircle);
+
+var _RadarRings = require('./RadarRings');
+
+var _RadarRings2 = _interopRequireDefault(_RadarRings);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var defaultRadarStyle = {
+  numRings: 4,
+  axisColor: '#cdcdcd',
+  ringColor: '#cdcdcd'
+};
+
+function getHovered(event, height, width, padding, radius, voronoiDiagram) {
+  var innerHeight = height - padding * 2;
+  var innerWidth = width - padding * 2;
+  var diameter = radius * 2;
+
+  var clientX = event.offsetX,
+      clientY = event.offsetY;
+
+  clientX -= padding;
+  clientY -= padding;
+  clientX -= (innerWidth - diameter) / 2;
+  clientY -= (innerHeight - diameter) / 2;
+
+  var site = voronoiDiagram.find(clientX, clientY, radius / 2);
+  if (!site) {
+    return null;
+  }
+
+  var data = site.data;
+
+  return data;
+}
+
+var RadarWrapper = function (_Component) {
+  _inherits(RadarWrapper, _Component);
+
+  function RadarWrapper() {
+    var _ref;
+
+    var _temp, _this, _ret;
+
+    _classCallCheck(this, RadarWrapper);
+
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = RadarWrapper.__proto__ || Object.getPrototypeOf(RadarWrapper)).call.apply(_ref, [this].concat(args))), _this), _this.hoverMap = null, _temp), _possibleConstructorReturn(_this, _ret);
+  }
+
+  _createClass(RadarWrapper, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      var _this2 = this;
+
+      if (this.hoverMap) {
+        this.hoverMap.addEventListener('mousemove', function (event) {
+          var onHover = _this2.props.onHover;
+
+          if (!onHover) {
+            return;
+          }
+          var _props = _this2.props,
+              padding = _props.padding,
+              height = _props.height,
+              width = _props.width,
+              radius = _props.radius,
+              voronoiDiagram = _props.voronoiDiagram;
+
+          onHover(getHovered(event, height, width, padding, radius, voronoiDiagram));
+        });
+      }
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _this3 = this;
+
+      var _props2 = this.props,
+          width = _props2.width,
+          height = _props2.height,
+          padding = _props2.padding,
+          radius = _props2.radius,
+          style = _props2.style,
+          highlighted = _props2.highlighted,
+          scales = _props2.scales,
+          variables = _props2.variables,
+          offsetAngles = _props2.offsetAngles,
+          domainMax = _props2.domainMax,
+          highlightedPoint = _props2.highlightedPoint,
+          regularPoints = _props2.regularPoints,
+          backgroundScale = _props2.backgroundScale,
+          colors = _props2.colors;
+
+      var diameter = radius * 2;
+
+      var _defaultRadarStyle$st = _extends({}, defaultRadarStyle, style),
+          axisColor = _defaultRadarStyle$st.axisColor,
+          ringColor = _defaultRadarStyle$st.ringColor,
+          numRings = _defaultRadarStyle$st.numRings;
+
+      var innerHeight = height - padding * 2;
+      var innerWidth = width - padding * 2;
+
+      var ticks = backgroundScale.ticks(numRings).slice(1);
+      var tickFormat = backgroundScale.tickFormat(numRings);
+
+      return _react2.default.createElement(
+        'svg',
+        { width: width, height: height },
+        _react2.default.createElement(
+          'g',
+          {
+            transform: 'translate(' + padding + ', ' + padding + ')',
+            ref: function ref(c) {
+              _this3.hoverMap = c;
+            }
+          },
+          _react2.default.createElement('rect', {
+            width: diameter,
+            height: diameter,
+            fill: 'transparent',
+            transform: 'translate(' + (innerWidth - diameter) / 2 + ', ' + (innerHeight - diameter) / 2 + ')'
+          }),
+          _react2.default.createElement(
+            'g',
+            { transform: 'translate(' + innerWidth / 2 + ', ' + innerHeight / 2 + ')' },
+            _react2.default.createElement(_RadarRings2.default, {
+              ticks: ticks,
+              scale: backgroundScale,
+              color: ringColor,
+              format: tickFormat
+            }),
+            variables.map(function (_ref2) {
+              var key = _ref2.key,
+                  label = _ref2.label;
+
+              return _react2.default.createElement(_RadarAxis2.default, {
+                key: key,
+                scale: scales[key],
+                offsetAngle: offsetAngles[key],
+                label: label,
+                domainMax: domainMax,
+                color: axisColor
+              });
+            }),
+            regularPoints.map(function (_ref3) {
+              var setKey = _ref3.setKey,
+                  points = _ref3.points;
+
+              return _react2.default.createElement(_RadarCircle2.default, {
+                key: setKey,
+                points: points,
+                scales: scales,
+                offsetAngles: offsetAngles,
+                color: colors[setKey],
+                isSelected: false,
+                selectedVariableKey: null
+              });
+            }),
+            highlightedPoint ? _react2.default.createElement(_RadarCircle2.default, {
+              key: highlightedPoint.setKey,
+              points: highlightedPoint.points,
+              scales: scales,
+              offsetAngles: offsetAngles,
+              color: colors[highlightedPoint.setKey],
+              isSelected: true,
+              selectedVariableKey: highlighted ? highlighted.variableKey : null
+            }) : null
+          )
+        )
+      );
+    }
+  }]);
+
+  return RadarWrapper;
+}(_react.Component);
+
+exports.default = RadarWrapper;

--- a/lib/RadarWrapper.js
+++ b/lib/RadarWrapper.js
@@ -174,20 +174,24 @@ var RadarWrapper = function (_Component) {
                 color: axisColor
               });
             }),
-            regularPoints.map(function (_ref3) {
-              var setKey = _ref3.setKey,
-                  points = _ref3.points;
+            _react2.default.createElement(
+              'g',
+              { className: 'data' },
+              regularPoints.map(function (_ref3) {
+                var setKey = _ref3.setKey,
+                    points = _ref3.points;
 
-              return _react2.default.createElement(_RadarCircle2.default, {
-                key: setKey,
-                points: points,
-                scales: scales,
-                offsetAngles: offsetAngles,
-                color: colors[setKey],
-                isSelected: false,
-                selectedVariableKey: null
-              });
-            }),
+                return _react2.default.createElement(_RadarCircle2.default, {
+                  key: setKey,
+                  points: points,
+                  scales: scales,
+                  offsetAngles: offsetAngles,
+                  color: colors[setKey],
+                  isSelected: false,
+                  selectedVariableKey: null
+                });
+              })
+            ),
             highlightedPoint ? _react2.default.createElement(_RadarCircle2.default, {
               key: highlightedPoint.setKey,
               points: highlightedPoint.points,

--- a/lib/RadarWrapper.js.flow
+++ b/lib/RadarWrapper.js.flow
@@ -1,0 +1,176 @@
+// @flow
+import React, {Component} from 'react';
+import type {TickScale, RadarPoint, RadarVariable} from './types';
+import RadarAxis from './RadarAxis';
+import RadarCircle from './RadarCircle';
+import RadarRings from './RadarRings';
+
+type Props = {
+  variables: Array<RadarVariable>,
+  width: number,
+  height: number,
+  padding: number,
+  domainMax: number,
+  style?: {},
+  onHover?: (point: RadarPoint | null) => void,
+  highlighted: ?RadarPoint,
+  scales: {[variableKey: string]: TickScale},
+  backgroundScale: TickScale,
+  offsetAngles: {[variableKey: string]: number},
+  voronoiDiagram: any,
+  radius: number,
+  highlightedPoint: ?{setKey: string, points: Array<RadarPoint>},
+  regularPoints: Array<{setKey: string, points: Array<RadarPoint>}>,
+  colors: {[setKey: string]: string},
+};
+
+const defaultRadarStyle = {
+  numRings: 4,
+  axisColor: '#cdcdcd',
+  ringColor: '#cdcdcd',
+};
+
+function getHovered(
+  event: MouseEvent,
+  height: number,
+  width: number,
+  padding: number,
+  radius: number,
+  voronoiDiagram: any,
+) {
+  const innerHeight = height - padding * 2;
+  const innerWidth = width - padding * 2;
+  const diameter = radius * 2;
+
+  let {offsetX: clientX, offsetY: clientY} = event;
+  clientX -= padding;
+  clientY -= padding;
+  clientX -= (innerWidth - diameter) / 2;
+  clientY -= (innerHeight - diameter) / 2;
+
+  const site = voronoiDiagram.find(clientX, clientY, radius / 2);
+  if (!site) {
+    return null;
+  }
+
+  const {data} = site;
+  return data;
+}
+
+export default class RadarWrapper extends Component {
+  props: Props;
+
+  hoverMap = null;
+
+  componentDidMount() {
+    if (this.hoverMap) {
+      this.hoverMap.addEventListener('mousemove', (event: MouseEvent) => {
+        const {onHover} = this.props;
+        if (!onHover) {
+          return;
+        }
+        const {padding, height, width, radius, voronoiDiagram} = this.props;
+        onHover(
+          getHovered(event, height, width, padding, radius, voronoiDiagram),
+        );
+      });
+    }
+  }
+
+  render() {
+    const {
+      width,
+      height,
+      padding,
+      radius,
+      style,
+      highlighted,
+      scales,
+      variables,
+      offsetAngles,
+      domainMax,
+      highlightedPoint,
+      regularPoints,
+      backgroundScale,
+      colors,
+    } = this.props;
+    const diameter = radius * 2;
+    const {axisColor, ringColor, numRings} = {...defaultRadarStyle, ...style};
+
+    const innerHeight = height - padding * 2;
+    const innerWidth = width - padding * 2;
+
+    const ticks = backgroundScale.ticks(numRings).slice(1);
+    const tickFormat = backgroundScale.tickFormat(numRings);
+
+    return (
+      <svg width={width} height={height}>
+        <g
+          transform={`translate(${padding}, ${padding})`}
+          ref={c => {
+            this.hoverMap = c;
+          }}
+        >
+          <rect
+            width={diameter}
+            height={diameter}
+            fill={'transparent'}
+            transform={
+              `translate(${(innerWidth - diameter) / 2}, ${(innerHeight -
+                diameter) /
+                2})`
+            }
+          />
+          <g transform={`translate(${innerWidth / 2}, ${innerHeight / 2})`}>
+            <RadarRings
+              ticks={ticks}
+              scale={backgroundScale}
+              color={ringColor}
+              format={tickFormat}
+            />
+            {variables.map(({key, label}) => {
+              return (
+                <RadarAxis
+                  key={key}
+                  scale={scales[key]}
+                  offsetAngle={offsetAngles[key]}
+                  label={label}
+                  domainMax={domainMax}
+                  color={axisColor}
+                />
+              );
+            })}
+            {regularPoints.map(({setKey, points}) => {
+              return (
+                <RadarCircle
+                  key={setKey}
+                  points={points}
+                  scales={scales}
+                  offsetAngles={offsetAngles}
+                  color={colors[setKey]}
+                  isSelected={false}
+                  selectedVariableKey={null}
+                />
+              );
+            })}
+            {
+              highlightedPoint
+                ? <RadarCircle
+                  key={highlightedPoint.setKey}
+                  points={highlightedPoint.points}
+                  scales={scales}
+                  offsetAngles={offsetAngles}
+                  color={colors[highlightedPoint.setKey]}
+                  isSelected={true}
+                  selectedVariableKey={
+                    highlighted ? highlighted.variableKey : null
+                  }
+                />
+                : null
+            }
+          </g>
+        </g>
+      </svg>
+    );
+  }
+}

--- a/lib/RadarWrapper.js.flow
+++ b/lib/RadarWrapper.js.flow
@@ -140,19 +140,23 @@ export default class RadarWrapper extends Component {
                 />
               );
             })}
-            {regularPoints.map(({setKey, points}) => {
-              return (
-                <RadarCircle
-                  key={setKey}
-                  points={points}
-                  scales={scales}
-                  offsetAngles={offsetAngles}
-                  color={colors[setKey]}
-                  isSelected={false}
-                  selectedVariableKey={null}
-                />
-              );
-            })}
+            <g className="data">
+              {
+                regularPoints.map(({setKey, points}) => {
+                  return (
+                    <RadarCircle
+                      key={setKey}
+                      points={points}
+                      scales={scales}
+                      offsetAngles={offsetAngles}
+                      color={colors[setKey]}
+                      isSelected={false}
+                      selectedVariableKey={null}
+                    />
+                  );
+                })
+              }
+            </g>
             {
               highlightedPoint
                 ? <RadarCircle

--- a/lib/react-d3-radar.js
+++ b/lib/react-d3-radar.js
@@ -1,0 +1,19 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.EmptyRadar = undefined;
+
+var _Radar = require('./Radar');
+
+var _Radar2 = _interopRequireDefault(_Radar);
+
+var _EmptyRadar = require('./EmptyRadar');
+
+var _EmptyRadar2 = _interopRequireDefault(_EmptyRadar);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = _Radar2.default;
+exports.EmptyRadar = _EmptyRadar2.default;

--- a/lib/react-d3-radar.js.flow
+++ b/lib/react-d3-radar.js.flow
@@ -1,0 +1,6 @@
+// @flow
+import Radar from './Radar';
+import EmptyRadar from './EmptyRadar';
+
+export default Radar;
+export {EmptyRadar};

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,1 @@
+"use strict";

--- a/lib/types.js.flow
+++ b/lib/types.js.flow
@@ -1,0 +1,28 @@
+// @flow
+export type TickScale = {
+  (d: number): number,
+  ticks(count: number): Array<number>,
+  tickFormat(count: number, fmt: ?string): (val: number) => string,
+};
+
+export type RadarVariable = {key: string, label: string};
+
+type RadarDataSet = {
+  key: string,
+  label: string,
+  values: {[variableKey: string]: number},
+};
+
+export type RadarData = {
+  variables: Array<RadarVariable>,
+  sets: Array<RadarDataSet>,
+};
+
+export type RadarPoint = {
+  x: number,
+  y: number,
+  value: number,
+  setKey: string,
+  variableKey: string,
+  key: string,
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,75 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.flatMapDeepArray = flatMapDeepArray;
+exports.forEachArray = forEachArray;
+exports.radiusScales = radiusScales;
+exports.radarPoints = radarPoints;
+
+var _lodash = require('lodash');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+var _d3Scale = require('d3-scale');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function flatMapDeepArray(collection, fn) {
+  return _lodash2.default.flatMapDeep(collection, fn);
+}
+function forEachArray(collection, fn) {
+  _lodash2.default.forEach(collection, fn);
+}
+
+function radiusScales(variables, domainMax, radius) {
+  var res = {};
+  _lodash2.default.forEach(variables, function (_ref) {
+    var key = _ref.key;
+
+    var scale = (0, _d3Scale.scaleLinear)().domain([0, domainMax]).range([0, radius]);
+    res[key] = scale;
+  });
+  return res;
+}
+
+function radarPoints(data, scales, offsetAngles) {
+  var allVariableKeys = data.variables.map(function (variable) {
+    return variable.key;
+  });
+
+  return data.sets.map(function (_ref2) {
+    var key = _ref2.key,
+        values = _ref2.values;
+
+    var points = [];
+    _lodash2.default.forEach(values, function (value, variableKey) {
+      var scale = scales[variableKey];
+      var offsetAngle = offsetAngles[variableKey];
+      if (scale === undefined || offsetAngle === undefined) {
+        return;
+      }
+
+      var x = scale(value) * Math.cos(offsetAngle - Math.PI / 2);
+      var y = scale(value) * Math.sin(offsetAngle - Math.PI / 2);
+
+      var point = {
+        x: x,
+        y: y,
+        value: value,
+        setKey: key,
+        variableKey: variableKey,
+        key: key + '--' + variableKey
+      };
+      points.push(point);
+    });
+
+    var sortedPoints = _lodash2.default.sortBy(points, function (point) {
+      var pointVariableKey = point.variableKey;
+      return _lodash2.default.indexOf(allVariableKeys, pointVariableKey);
+    });
+
+    return { setKey: key, points: sortedPoints };
+  });
+}

--- a/lib/utils.js.flow
+++ b/lib/utils.js.flow
@@ -1,0 +1,69 @@
+// @flow
+import _ from 'lodash';
+import {scaleLinear} from 'd3-scale';
+import type {TickScale, RadarPoint, RadarData, RadarVariable} from './types';
+
+export function flatMapDeepArray<T, R>(
+  collection: Array<T>,
+  fn: (d: T) => Array<R>,
+): Array<R> {
+  return _.flatMapDeep(collection, fn);
+}
+export function forEachArray<T>(
+  collection: Array<T>,
+  fn: (item: T, idx: number) => void,
+): void {
+  _.forEach(collection, fn);
+}
+
+export function radiusScales(
+  variables: Array<RadarVariable>,
+  domainMax: number,
+  radius: number,
+): {[variableKey: string]: TickScale} {
+  const res = {};
+  _.forEach(variables, ({key}) => {
+    const scale = scaleLinear().domain([0, domainMax]).range([0, radius]);
+    res[key] = scale;
+  });
+  return res;
+}
+
+export function radarPoints(
+  data: RadarData,
+  scales: {[variableKey: string]: TickScale},
+  offsetAngles: {[variableKey: string]: number},
+): Array<{setKey: string, points: Array<RadarPoint>}> {
+  const allVariableKeys = data.variables.map(variable => variable.key);
+
+  return data.sets.map(({key, values}) => {
+    const points = [];
+    _.forEach(values, (value, variableKey) => {
+      const scale = scales[variableKey];
+      const offsetAngle = offsetAngles[variableKey];
+      if (scale === undefined || offsetAngle === undefined) {
+        return;
+      }
+
+      const x = scale(value) * Math.cos(offsetAngle - Math.PI / 2);
+      const y = scale(value) * Math.sin(offsetAngle - Math.PI / 2);
+
+      const point = {
+        x,
+        y,
+        value,
+        setKey: key,
+        variableKey,
+        key: `${key}--${variableKey}`,
+      };
+      points.push(point);
+    });
+
+    const sortedPoints = _.sortBy(points, point => {
+      const pointVariableKey = point.variableKey;
+      return _.indexOf(allVariableKeys, pointVariableKey);
+    });
+
+    return {setKey: key, points: sortedPoints};
+  });
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "d3-scale": "^1.0.4",
     "d3-shape": "^1.0.4",
     "d3-voronoi": "^1.1.1",
+    "invariant": "^2.2.2",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/src/Radar.js
+++ b/src/Radar.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {schemeCategory10} from 'd3-scale';
 import {voronoi} from 'd3-voronoi';
 import _ from 'lodash';
+import invariant from 'invariant';
 import {
   flatMapDeepArray,
   forEachArray,
@@ -61,6 +62,9 @@ export default function Radar(props: Props) {
     onHover,
     highlighted,
   } = props;
+
+  invariant(data, 'The `data` property should be non-null.');
+
   const {allPoints, scales, offsetAngles, radius, voronoiDiagram} = convertData(
     props,
   );

--- a/src/RadarAxis.js
+++ b/src/RadarAxis.js
@@ -13,7 +13,7 @@ type RadarAxisProps = {
 
 const defaultRadarAxisStyle = {
   axisOverreach: 1.1,
-  labelOverreach: 1.2,
+  labelOverreach: 1.42,
   fontSize: 10,
   fontFamily: 'sans-serif',
   textFill: 'black',
@@ -42,17 +42,16 @@ export default function RadarAxis(props: RadarAxisProps) {
         stroke={color}
         strokeWidth={axisWidth}
       />
-      <text
-        x={scale(domainMax * labelOverreach) * xFactor}
-        y={scale(domainMax * labelOverreach) * yFactor}
-        fontSize={fontSize}
-        fontFamily={fontFamily}
-        fill={textFill}
-        textAnchor={'middle'}
+      <foreignObject
+        x={scale(((domainMax * labelOverreach) * xFactor) - 26)}
+        y={scale(((domainMax * labelOverreach) * (yFactor * 0.87)) - 7)}
         dy={'0.35em'}
+        dx={'0.35em'}
       >
-        {label}
-      </text>
+        <div>
+          <p>{label}</p>
+        </div>
+      </foreignObject>
     </g>
   );
 }

--- a/src/RadarWrapper.js
+++ b/src/RadarWrapper.js
@@ -140,19 +140,23 @@ export default class RadarWrapper extends Component {
                 />
               );
             })}
-            {regularPoints.map(({setKey, points}) => {
-              return (
-                <RadarCircle
-                  key={setKey}
-                  points={points}
-                  scales={scales}
-                  offsetAngles={offsetAngles}
-                  color={colors[setKey]}
-                  isSelected={false}
-                  selectedVariableKey={null}
-                />
-              );
-            })}
+            <g className="data">
+              {
+                regularPoints.map(({setKey, points}) => {
+                  return (
+                    <RadarCircle
+                      key={setKey}
+                      points={points}
+                      scales={scales}
+                      offsetAngles={offsetAngles}
+                      color={colors[setKey]}
+                      isSelected={false}
+                      selectedVariableKey={null}
+                    />
+                  );
+                })
+              }
+            </g>
             {
               highlightedPoint
                 ? <RadarCircle


### PR DESCRIPTION
## Why is this change necessary?

- If a falsy `data` prop is passed in to a `Radar` component then a deep React rendering error occurs.

## How does it address the issue?

- Adding `invariant` (for meaningful errors in non-`PRODUCTION` envs) to log if `data` is passed with a falsy value.

## What side effects does this change have?

- None

## How was it tested?

- Should pass test suite