### PR TITLE
add onAxisLabelMouseover prop to RadarAxis

### DIFF
--- a/src/Radar.js
+++ b/src/Radar.js
@@ -22,6 +22,7 @@ type Props = {
   onHover?: (point: RadarPoint | null) => void,
   highlighted: ?RadarPoint,
   onAxisLabelClick?: ({ variableKey: string, label: string }) => void,
+  onAxisLabelMouseover?: ({ variableKey: string, label: string }) => void,
   axisLabelTextStyle?: {}
 };
 
@@ -67,6 +68,7 @@ export default function Radar(props: Props) {
     onHover,
     highlighted,
     onAxisLabelClick,
+    onAxisLabelMouseover,
     axisLabelTextStyle
   } = props;
 
@@ -117,6 +119,7 @@ export default function Radar(props: Props) {
       regularPoints={regularPoints}
       colors={colors}
       onAxisLabelClick={onAxisLabelClick}
+      onAxisLabelMouseover={onAxisLabelMouseover}
       axisLabelTextStyle={axisLabelTextStyle}
     />
   );

--- a/src/RadarAxis.js
+++ b/src/RadarAxis.js
@@ -11,6 +11,7 @@ type RadarAxisProps = {
   color: string,
   style?: {},
   onAxisLabelClick?: ({ variableKey: string, label: string }) => void,
+  onAxisLabelMouseover?: ({ variableKey: string, label: string }) => void,
   textStyle: ?{}
 };
 
@@ -32,6 +33,7 @@ export default function RadarAxis(props: RadarAxisProps) {
     color,
     style,
     onAxisLabelClick,
+    onAxisLabelMouseover,
     variableKey,
     textStyle
   } = props;
@@ -48,6 +50,10 @@ export default function RadarAxis(props: RadarAxisProps) {
 
   const onClick = onAxisLabelClick
     ? () => onAxisLabelClick({ variableKey, label })
+    : null;
+
+  const onMouseover = onAxisLabelMouseover
+    ? () => onAxisLabelMouseover({ variableKey, label })
     : null;
 
   return (
@@ -69,7 +75,7 @@ export default function RadarAxis(props: RadarAxisProps) {
         textAnchor={"middle"}
         dy={"0.35em"}
         onClick={onClick}
-        onMouseOver={onClick}
+        onMouseOver={onMouseover}
         style={textStyle}
       >
         {label}

--- a/src/RadarWrapper.js
+++ b/src/RadarWrapper.js
@@ -23,6 +23,7 @@ type Props = {
   regularPoints: Array<{ setKey: string, points: Array<RadarPoint> }>,
   colors: { [setKey: string]: string },
   onAxisLabelClick?: ({ variableKey: string, label: string }) => void,
+  onAxisLabelMouseover?: ({ variableKey: string, label: string }) => void,
   axisLabelTextStyle: ?{}
 };
 
@@ -94,6 +95,7 @@ export default class RadarWrapper extends Component<Props> {
       backgroundScale,
       colors,
       onAxisLabelClick,
+      onAxisLabelMouseover,
       axisLabelTextStyle
     } = this.props;
     const diameter = radius * 2;
@@ -146,6 +148,7 @@ export default class RadarWrapper extends Component<Props> {
                   domainMax={domainMax}
                   color={axisColor}
                   onAxisLabelClick={onAxisLabelClick}
+                  onAxisLabelMouseover={onAxisLabelMouseover}
                   textStyle={axisLabelTextStyle}
                 />
               );


### PR DESCRIPTION
add an onAxisLabelMouseover prop to RadarAxis, Radar, and RadarWrapper so that mousing over an axis label and clicking on an axis label can be set separately.

Resolves #13 