### PR TITLE
Allow to define fontSize from outside

### DIFF
--- a/src/RadarWrapper.js
+++ b/src/RadarWrapper.js
@@ -137,6 +137,7 @@ export default class RadarWrapper extends Component {
                   label={label}
                   domainMax={domainMax}
                   color={axisColor}
+                  style={style}
                 />
               );
             })}


### PR DESCRIPTION
Passing style down to RadarAxis should enable us to override fontSize.